### PR TITLE
Fix what I just broke

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -36,7 +36,7 @@ on:
       build_command:
         description: 'The linux command to build the book or site.'
         required: false
-        default: 'jupyter-book build ${{ inputs.path_to_notebooks }}'
+        default: 'jupyter-book build .'
         type: string
 
     secrets:
@@ -162,6 +162,7 @@ jobs:
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
         run: |
+          cd ${{ inputs.path_to_notebooks }}
           ${{ inputs.build_command }}
 
       - name: Zip the book


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Seems that the variable substitution `${{ inputs.path_to_notebooks }}` doesn't work when we're still in the inputs section. This is a workaround.