### PR TITLE
New build_command argument for link-checker.yaml

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -23,6 +23,12 @@ on:
         required: false
         default: 'true'
         type: string
+      build_command:
+        description: 'The linux command to run the link checker for the book or site'
+        required: false
+        default: 'jupyter-book build --builder linkcheck .'
+        type: string
+
 
 concurrency:
   group: ${{ github.workflow }}=${{ github.head_ref}}
@@ -59,4 +65,5 @@ jobs:
 
       - name: Check external links
         run: |
-          jupyter-book build --builder linkcheck ${{ inputs.path_to_notebooks }}
+          cd ${{ inputs.path_to_notebooks }}
+          ${{ inputs.build_command }}


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This adds an optional `build_command` input argument for the `link-checker.yaml` workflow, similar to the `build-book.yaml` workflow.

The use case is passing `make linkcheck` to run the sphinx link-checker for repos that are build with Sphinx rather than JupyterBook.