### PR TITLE
Ensure env is rebuilt when use cached env is set to false

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -113,7 +113,7 @@ jobs:
         if: |
           (inputs.use_cached_environment != 'true'
           || steps.cache.outputs.cache-hit != 'true')
-          && steps.parse_config.outputs.execute_notebooks != 'binder'
+          && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
 
       - name: Get paths to notebook files


### PR DESCRIPTION
This fixes a potential bug in the existing book building code. This is preventing the cmip6-cookbook from rebuilding the image
