### PR TITLE
Enable custom `publish_dir` in deploy-book action

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -23,6 +23,11 @@ on:
         required: false
         default: 'None'  # This is just a flag for whether to ignore this input
         type: string
+      publish_dir:
+        description: 'Publish dir for the peaceiris/actions-gh-pages action'
+        required: false
+        default: '_build/html'
+        type: string
       
 jobs:
   deploy:
@@ -61,7 +66,7 @@ jobs:
           && inputs.cname == 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/html
+          publish_dir: {{ inputs.publish_dir }}
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs
           destination_dir: ${{ inputs.destination_dir }}
@@ -73,7 +78,7 @@ jobs:
           && inputs.cname != 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/html
+          publish_dir: {{ inputs.publish_dir }}
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -66,7 +66,7 @@ jobs:
           && inputs.cname == 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: {{ inputs.publish_dir }}
+          publish_dir: ${{ inputs.publish_dir }}
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs
           destination_dir: ${{ inputs.destination_dir }}
@@ -78,7 +78,7 @@ jobs:
           && inputs.cname != 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: {{ inputs.publish_dir }}
+          publish_dir: ${{ inputs.publish_dir }}
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs
           destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
I have been implementing these actions over at the [LEAP Technical Docs](https://github.com/leap-stc/leap-stc.github.io), but I am running into issues since our book directory (and the resulting build directory) is nested one level down from the root. 

I believe if I can specify the `publish_dir` with a custom value (see [our old deploy script](https://github.com/leap-stc/leap-stc.github.io/blob/9819491a2a508e54ec7633cf2d57a3a2c29cd99c/.github/workflows/deploy.yaml#L45)) this would enable me to fully reuse this set of actions.

I will test this out over there and report back. 