### PR TITLE
Add trailing slash to preview url

### DIFF
--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -72,4 +72,4 @@ jobs:
           body: |
             ${{ env.comment_message }}
             🔍 Git commit SHA: ${{ inputs.sha }}
-            ✅ Deployment Preview URL: https://${{ github.repository_owner }}.github.io/${{ steps.repo-name.outputs.value }}/_preview/${{ inputs.pull_request_number }}
+            ✅ Deployment Preview URL: https://${{ github.repository_owner }}.github.io/${{ steps.repo-name.outputs.value }}/_preview/${{ inputs.pull_request_number }}/


### PR DESCRIPTION
I noticed that in testing these actions for our [docs](https://github.com/leap-stc/leap-stc.github.io/pull/48) the link does not actually show the preview build. Adding a trailing slash fixed this for me.

I wonder why that is not the case for comments on [ProjPythia PRs](https://github.com/ProjectPythia/pythia-foundations/pull/369)? 
