### PR TITLE
Adapt preview URL for org or project site

### DIFF
--- a/.github/workflows/preview-comment.yaml
+++ b/.github/workflows/preview-comment.yaml
@@ -33,6 +33,15 @@ jobs:
         run: |
           echo "comment_message=👋 Thanks for opening this PR! ${{ inputs.site_name }} will be automatically built with [GitHub Actions](https://github.com/features/actions). To see the status of your deployment, click below." >> $GITHUB_ENV
 
+      - name: Set preview URL
+        run: |
+          if [${{ steps.repo-name.outputs.value }} = ${{ github.repository_owner }}.github.io]
+          then
+            echo "previewURL=https://${{ steps.repo-name.outputs.value }}/_preview/${{ inputs.pull_request_number }}"
+          else
+            echo "previewURL=https://${{ github.repository_owner }}.github.io/${{ steps.repo-name.outputs.value }}/_preview/${{ inputs.pull_request_number }}"
+          fi
+
       - name: Find preview comment
         uses: peter-evans/find-comment@v2
         id: fc
@@ -77,4 +86,4 @@ jobs:
           body: |
             ${{ env.comment_message }}
             🔍 Git commit SHA: ${{ inputs.sha }}
-            ✅ Deployment Preview URL: https://${{ github.repository_owner }}.github.io/${{ steps.repo-name.outputs.value }}/_preview/${{ inputs.pull_request_number }}
+            ✅ Deployment Preview URL: ${{ env.previewURL }}


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Addresses #47 and https://github.com/ProjectPythia/projectpythia.github.io/issues/329

The preview workflow checks to see if the repo name matches the pattern `{repo owner}.github.io`, in which case this is a ["User/Org" site](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites) rather than a Project site.

User/Org sites post the preview to `https://{repo owner}.github.io/_preview/{PR number}`, whereas Project sites post the preview to `https://{repo owner}.github.io/{repo name}/_preview/{PR number}`.