### PR TITLE
Make path to output an input argument

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -33,6 +33,11 @@ on:
         required: false
         default: 'jupyter-book build .'
         type: string
+      output_path:
+        description: 'Path to the built html content relative to `path_to_notebooks`'
+        required: false
+        default: '_build/html'
+        type: string
 
     secrets:
       ARM_USERNAME:
@@ -193,7 +198,7 @@ jobs:
           if [ -f book.zip ]; then
               rm -rf book.zip
           fi
-          zip -r book.zip ${{ inputs.path_to_notebooks }}/_build/html
+          zip -r book.zip ${{ inputs.path_to_notebooks }}/ ${{ inputs.output_path }}
 
       - name: Upload zipped book artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Over at https://github.com/leap-stc/ClimSim/tree/main I am using the `jb-article` format and also specify a custom builder to concatenate several source files into one html page. 

This somehow puts the built html into a different subfolder. `_build/singlehtml` vs the hardcoded `_build/html`. 

This PR enables the user to specify the output directory. 

> I suspect that the output files are always put into a `_build/<builder specified>` scheme? So maybe the input should rather be the builder only? Or are there cases where the `_build` part of the path is named differently? 