### PR TITLE
Add option to change binder timeout

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -38,6 +38,11 @@ on:
         required: false
         default: '_build/html'
         type: string
+      binder_nb_timeout:
+        description: 'Maximum execution time (in seconds) for each notebook on the binder.'
+        required: false
+        default: 600
+        type: number
 
     secrets:
       ARM_USERNAME:
@@ -142,6 +147,7 @@ jobs:
           for path in notebooks:
               outfile.write(path + ' ')
           outfile.close() # Writing these out to a file because I can't figure out how to set an environment variable from a python script 
+
       - name: Execute notebooks via binderbot using existing image
         if: |
           ( steps.parse_config.outputs.execute_notebooks == 'binder'
@@ -157,7 +163,7 @@ jobs:
           echo "using the existing binder image from the main branch"
           SECRET_VAR_LIST=$(echo $SECRET_VARS | jq -r 'with_entries(.key |= "--pass-env-var " + . + " ") | keys | [ .[] | tostring ] | @csv') # Extract the keys of the secret environment variables, and create a list of arguments separated by commas (CSV)
           SECRET_VARS_ARGS=$(echo "${SECRET_VAR_LIST//,}" | tr -d '"') # Remove the commas and merge the list of strings into a single cohesive string to be passed to the binder cli
-          python -m binderbot.cli --binder-url ${{ steps.parse_config.outputs.binderhub_url }} --repo ${{ github.repository }} --ref main $NOTEBOOKS $SECRET_VARS_ARGS
+          python -m binderbot.cli --binder-url ${{ steps.parse_config.outputs.binderhub_url }} --repo ${{ github.repository }} --ref main --nb-timeout ${{ inputs.binder_nb_timeout }} $NOTEBOOKS $SECRET_VARS_ARGS
 
       - name: Execute notebooks via binderbot using new image with latest environment
         if: |
@@ -171,7 +177,7 @@ jobs:
           echo 'Retrieved binder_url: ${{ steps.parse_config.outputs.binderhub_url }}'
           echo "We will now execute these notebooks: $NOTEBOOKS"
           echo "using the updated environment file in this branch to build a new image"
-          python -m binderbot.cli --binder-url ${{ steps.parse_config.outputs.binderhub_url }} --repo ${{ github.repository }} --ref ${{ github.ref }} $NOTEBOOKS
+          python -m binderbot.cli --binder-url ${{ steps.parse_config.outputs.binderhub_url }} --repo ${{ github.repository }} --ref ${{ github.ref }} --nb-timeout ${{ inputs.binder_nb_timeout }} $NOTEBOOKS
 
       - name: Disable notebook execution during jupyterbook build
         if: |


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Adds new input argument for the `build-book.yaml` workflow
```
binder_nb_timeout
```
which gets passed on to binderbot as `--nb-timeout`. The default value is 600 seconds which matches the existing binderbot default.

Should be backwards-compatible, and won't affect builds that don't use binderbot.

This will enable building heavier-duty Cookbooks (https://github.com/ProjectPythia/cesm-lens-aws-cookbook/pull/16)