### PR TITLE
Add missing secrets in non-binder build

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -193,6 +193,10 @@ jobs:
 
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
+        env:
+          ARM_USERNAME: ${{ secrets.ARM_USERNAME }}
+          ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
+          SECRETS_VARS: ${{ toJson(secrets) }}
         run: |
           cd ${{ inputs.path_to_notebooks }}
           ${{ inputs.build_command }}


### PR DESCRIPTION
Currently, we are not passing the secrets to the build command on Github actions. This makes sure that is added in.
