### PR TITLE
Update build-book.yaml to temporarily fix nightly build failures with Sphinx version issue

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -165,7 +165,9 @@ jobs:
           || steps.cache.outputs.cache-hit != 'true'
           || steps.env_change.outputs.any_changed == 'true')
           && steps.parse_config.outputs.execute_notebooks != 'binder'
-        run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
+        run: |
+          mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
+          mamba install -c conda-forge sphinxcontrib-applehelp=1.0.7
 
       - name: Get paths to notebook files
         if: |


### PR DESCRIPTION
Pin `sphinxcontrib-applehelp` to 1.0.7 to fix [cookbook-template - Issue #154](https://github.com/ProjectPythia/cookbook-template/issues/154) for now (until the theme issues can be fixed permanently).
