### PR TITLE
Update build-book.yaml to temporarily pin sphinxcontrib-... packages

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -167,7 +167,7 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks != 'binder'
         run: |
           mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-          mamba install -c conda-forge sphinxcontrib-applehelp=1.0.7
+          mamba install -c conda-forge sphinxcontrib-applehelp=1.0.7 sphinxcontrib-devhelp=1.0.5 sphinxcontrib-htmlhelp=2.0.4 sphinxcontrib-qthelp=1.0.6 sphinxcontrib-serializinghtml=1.1.9
 
       - name: Get paths to notebook files
         if: |


### PR DESCRIPTION
PR #91 had touched only `sphinxcontrib-applehelp` for temporarily pinning it to get Cookbook builds up and running again. However, it turned out it was not sufficient, several other `sphinxcontrib-...` packages have also been updated over a few days ago (e.g. now `sphinxcontrib-devhelp` started to fail the cookbook builds). This PR pins them all to their previous versions with which our Cookbooks had built successfully. 

Additionally, issue #93 has been created to take care of these temporary pinnings in the future once we have an updated Sphinx theme.