### PR TITLE
Make `workflow-trigger` an input to download artifact step

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -48,6 +48,10 @@ on:
         required: false
         default: 'code-zip'
         type: string
+      input_workflow:
+        description: 'Identify the workflow that produced the artifact'
+        required: false
+        default: trigger-book-build.yaml
 
     secrets:
       ARM_USERNAME:
@@ -75,6 +79,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: input.trigger-workflow
           run_id: ${{ github.event.workflow_run.id }}
           name: ${{ inputs.code_artifact_name }}
 

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -44,7 +44,7 @@ on:
         default: 'false'
         type: string
       code_artifact_name:
-        description:
+        description: 'Name of zipped artifact passed in, instead of checking out the repository.'
         required: false
         default: 'code-zip'
         type: string
@@ -75,7 +75,6 @@ jobs:
         uses: dawidd6/action-download-artifact@v3.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: trigger-book-build.yaml
           run_id: ${{ github.event.workflow_run.id }}
           name: ${{ inputs.code_artifact_name }}
 

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -48,7 +48,7 @@ on:
         required: false
         default: 'code-zip'
         type: string
-      input_workflow:
+      trigger_workflow:
         description: 'Identify the workflow that produced the artifact'
         required: false
         default: trigger-book-build.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: input.trigger-workflow
+          workflow: input.trigger_workflow
           run_id: ${{ github.event.workflow_run.id }}
           name: ${{ inputs.code_artifact_name }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDEs
+settings.json


### PR DESCRIPTION
I am unsure on why this step to trigger the build-build lives inside of the book-build. Let me know what you think.

E: Thanks @brian-rose for explaining that it doesn't trigger the trigger-book-build.yaml workflow, but tells the book-build action to look in that action for the artifact.

Related to https://github.com/ProjectPythia/projectpythia.github.io/pull/415 and https://github.com/ProjectPythia/projectpythia.github.io/issues/319
