### PR TITLE
missing type for trigger_workflow

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -52,6 +52,7 @@ on:
         description: 'Identify the workflow that produced the artifact'
         required: false
         default: trigger-book-build.yaml
+        type: string
 
     secrets:
       ARM_USERNAME:


### PR DESCRIPTION
Getting error:
```
[Invalid workflow file: .github/workflows/nightly-build.yaml#L11](https://github.com/jukent/projectpythia.github.io/actions/runs/8398301725/workflow)
The workflow is not valid. In .github/workflows/nightly-build.yaml (Line: 11, Col: 11): Error from called workflow ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main (Line: 52, Col: 9): Required property is missing: type
```
This specifies that it is a string. 