### PR TITLE
Update build-book.yaml to fix input workflow

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: input.trigger_workflow
+          workflow: ${{ inputs.trigger_workflow }}
           run_id: ${{ github.event.workflow_run.id }}
           name: ${{ inputs.code_artifact_name }}
 


### PR DESCRIPTION
From my branch action's error:
```
Run dawidd6/action-download-artifact@v3.1.4
==> Repository: jukent/projectpythia.github.io
==> Artifact name: repo-zip
==> Local path: ./
==> Workflow name: input.trigger_workflow
==> Workflow conclusion: success
==> Allow forks: true
Error: Not Found - https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow
```

I made one of 2 mistakes (or both). The action looks for a workflow called input.trigger_workflow, instead of looking for what was inputed. It should be inputs (plural) and potentially have curly brackets around it to indicate that it is a variable. 

Related to https://github.com/ProjectPythia/projectpythia.github.io/issues/319 and https://github.com/ProjectPythia/projectpythia.github.io/pull/415
