### PR TITLE
Remove temporary sphinx-contrib... pins

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -179,7 +179,6 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks != 'binder'
         run: |
           mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-          mamba install -c conda-forge sphinxcontrib-applehelp=1.0.4 sphinxcontrib-devhelp=1.0.2 sphinxcontrib-htmlhelp=2.0.1 sphinxcontrib-qthelp=1.0.3 sphinxcontrib-serializinghtml=1.1.5
 
       - name: Get paths to notebook files
         if: |


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
We shouldn't need to pin sphinx packages anymore with the release of sphinx-pythia-theme v2024.3.0.

This PR removes the temporary pins, and should close #93 