### PR TITLE
Start using the updated theme

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -158,6 +158,7 @@ jobs:
           mamba install -c conda-forge jupyter-book pip
           pip install sphinx-pythia-theme
           pip install git+https://github.com/pangeo-gallery/binderbot.git
+          mamba list
 
       - name: Update execution environment
         if: |

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -156,7 +156,7 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: |
           mamba install -c conda-forge jupyter-book pip
-          pip install git+https://github.com/ProjectPythia/sphinx-pythia-theme.git@theme-update
+          pip install git+https://github.com/ProjectPythia/sphinx-pythia-theme.git@theme-update-more
           pip install git+https://github.com/pangeo-gallery/binderbot.git
 
       - name: Update execution environment

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -156,7 +156,7 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: |
           mamba install -c conda-forge jupyter-book pip
-          pip install git+https://github.com/ProjectPythia/sphinx-pythia-theme.git@theme-update
+          pip install sphinx-pythia-theme
           pip install git+https://github.com/pangeo-gallery/binderbot.git
 
       - name: Update execution environment

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -156,7 +156,7 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: |
           mamba install -c conda-forge jupyter-book pip
-          pip install sphinx-pythia-theme
+          pip install git+https://github.com/ProjectPythia/sphinx-pythia-theme.git@theme-update
           pip install git+https://github.com/pangeo-gallery/binderbot.git
 
       - name: Update execution environment
@@ -167,7 +167,6 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks != 'binder'
         run: |
           mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-          mamba install -c conda-forge sphinxcontrib-applehelp=1.0.7 sphinxcontrib-devhelp=1.0.5 sphinxcontrib-htmlhelp=2.0.4 sphinxcontrib-qthelp=1.0.6 sphinxcontrib-serializinghtml=1.1.9
 
       - name: Get paths to notebook files
         if: |

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -167,7 +167,9 @@ jobs:
           || steps.env_change.outputs.any_changed == 'true')
           && steps.parse_config.outputs.execute_notebooks != 'binder'
         run: |
+          mamba list
           mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
+          mamba list
 
       - name: Get paths to notebook files
         if: |

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -156,7 +156,7 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: |
           mamba install -c conda-forge jupyter-book pip
-          pip install git+https://github.com/ProjectPythia/sphinx-pythia-theme.git@theme-update-more
+          pip install git+https://github.com/ProjectPythia/sphinx-pythia-theme.git@theme-update
           pip install git+https://github.com/pangeo-gallery/binderbot.git
 
       - name: Update execution environment

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -156,7 +156,7 @@ jobs:
           && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: |
           mamba install -c conda-forge jupyter-book pip
-          pip install sphinx-pythia-theme
+          mamba install sphinx-pythia-theme
           pip install git+https://github.com/pangeo-gallery/binderbot.git
           mamba list
 

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Deploy to GitHub Pages with custom domain
         uses: peaceiris/actions-gh-pages@v3.9.3
         if: |
-          (github.ref == 'refs/heads/main'
+          (github.ref == 'refs/heads/try_updated_theme'
           && inputs.cname != 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3.9.3
         if: |
-          (github.ref == 'refs/heads/main'
+          (github.ref == 'refs/heads/try_updated_theme'
           && inputs.cname == 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3.9.3
         if: |
-          (github.ref == 'refs/heads/try_updated_theme'
+          (github.ref == 'refs/heads/main'
           && inputs.cname == 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
       - name: Deploy to GitHub Pages with custom domain
         uses: peaceiris/actions-gh-pages@v3.9.3
         if: |
-          (github.ref == 'refs/heads/try_updated_theme'
+          (github.ref == 'refs/heads/main'
           && inputs.cname != 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since PR #108 got rid of the pins for older versions of several packages we had had to use with the older pythia theme, no much change was needed here since "Update execution env" step uses the env file of whatever repo calls book build.
