### PR TITLE
Switch from mambaforge to miniforge

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -151,14 +151,12 @@ jobs:
           echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
           echo ${{ steps.env_change.outputs.any_changed }}
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: "3.10"  # binderbot is failing with python 3.11
           activate-environment: ${{ inputs.environment_name }}
-          use-mamba: true
 
       - name: Set cache date
         if: inputs.use_cached_environment == 'true'
@@ -179,10 +177,10 @@ jobs:
           || steps.cache.outputs.cache-hit != 'true')
           && steps.parse_config.outputs.execute_notebooks == 'binder'
         run: |
-          mamba install -c conda-forge jupyter-book pip
-          mamba install sphinx-pythia-theme
+          conda install -c conda-forge jupyter-book pip
+          conda install sphinx-pythia-theme
           pip install git+https://github.com/pangeo-gallery/binderbot.git
-          mamba list
+          conda list
 
       - name: Update execution environment
         if: |
@@ -191,8 +189,8 @@ jobs:
           || steps.env_change.outputs.any_changed == 'true')
           && steps.parse_config.outputs.execute_notebooks != 'binder'
         run: |
-          mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-          mamba list
+          conda env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
+          conda list
 
       - name: Get paths to notebook files
         if: |

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -43,15 +43,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
 
       - name: Install Jupyterbook
-        run: mamba install -c conda-forge jupyter-book
+        run: conda install -c conda-forge jupyter-book
 
       - name: Check for config file
         id: check_config


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Closes #123 

This PR replaces Mambaforge with Miniforge (and `mamba` commands with `conda`) throughout our workflows. Function should be identical. The change is necessary due to the [sunsetting of Mambaforge](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/).