### PR TITLE
pin to Python < 3.13

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -49,7 +49,7 @@ jobs:
           miniforge-version: latest
 
       - name: Install Jupyterbook
-        run: conda install -c conda-forge jupyter-book
+        run: conda install -c conda-forge jupyter-book python<3.13  # see https://github.com/ProjectPythia/cookbook-actions/issues/126
 
       - name: Check for config file
         id: check_config


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This should resolve #126 and get the link checker running again.

We can leave #126 open until things are fixed upstream and the version pin can be removed.