### PR TITLE
Potential follow up fix for #125

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -61,6 +61,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Debug
+        run: pwd
+
+      - name: Debug
+        run: ls -la
+
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         if: |

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -36,6 +36,8 @@ jobs:
       run:
         shell: bash -l {0}
     steps: 
+      - uses: actions/checkout@v4
+      
       - name: Download merged artifact
         if: inputs.is_preview != 'true'
         uses: actions/download-artifact@v4
@@ -58,8 +60,6 @@ jobs:
           rm -rf _build/html
           unzip book.zip
           rm -f book.zip
-
-      - uses: actions/checkout@v4
 
       - name: Debug
         run: pwd

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -65,7 +65,7 @@ jobs:
         run: pwd
 
       - name: Debug
-        run: ls -la
+        run: ls -la book/_build/html
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -64,22 +64,22 @@ jobs:
         if: |
           (github.ref == 'refs/heads/main' && inputs.cname == 'None')
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: ${{ inputs.publish_dir }}
-          CLEAN: true
-          KEEP_HISTORY: false
-          BASE_PATH: ${{ inputs.destination_dir }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: ${{ inputs.publish_dir }}
+          clean: true
+          clean-exclude: "preview" # keep existing previews from other PRs
+          target-folder: ${{ inputs.destination_dir }}
 
       - name: Deploy to GitHub Pages with custom domain
         uses: JamesIves/github-pages-deploy-action@v4
         if: |
           (github.ref == 'refs/heads/main' && inputs.cname != 'None')
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: ${{ inputs.publish_dir }}
-          CLEAN: true
-          KEEP_HISTORY: false
-          BASE_PATH: ${{ inputs.destination_dir }}
-          CNAME: ${{ inputs.cname }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: ${{ inputs.publish_dir }}
+          clean: true
+          clean-exclude: "preview" # keep existing previews from other PRs
+          target-folder: ${{ inputs.destination_dir }}
+          CNAME: ${{ inputs.cname }} # how can we set this for the new action?

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -59,6 +59,8 @@ jobs:
           unzip book.zip
           rm -f book.zip
 
+      - uses: actions/checkout@v4
+
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         if: |


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This is an attempt to fix our deployment over at https://github.com/leap-stc/leap-stc.github.io which broke after #125 (I foolishly used @main)

I think that the input names needed to be adjusted, but crucially I had to checkout the repo in the deploy workflow to get this to run. 

I have confirmed that our [main deployment](https://github.com/leap-stc/leap-stc.github.io/actions/runs/11404520305) and a [test PR](https://github.com/leap-stc/leap-stc.github.io/pull/190).

Overall I think this emphasizes the need for #6. Some sort of an end-to-end test would have presumably caught this? 