### PR TITLE
Remove custom domain name option

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -18,11 +18,6 @@ on:
         required: false
         default: 'false'
         type: string
-      cname:
-        description: 'Custom domain name'
-        required: false
-        default: 'None'  # This is just a flag for whether to ignore this input
-        type: string
       publish_dir:
         description: 'Publish dir for the action'
         required: false
@@ -64,7 +59,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         if: |
-          (github.ref == 'refs/heads/main' && inputs.cname == 'None')
+          (github.ref == 'refs/heads/main')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
@@ -72,16 +67,3 @@ jobs:
           clean: true
           clean-exclude: _preview/*  # keep existing previews from other PRs
           target-folder: ${{ inputs.destination_dir }}
-
-      - name: Deploy to GitHub Pages with custom domain
-        uses: JamesIves/github-pages-deploy-action@v4
-        if: |
-          (github.ref == 'refs/heads/main' && inputs.cname != 'None')
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: ${{ inputs.publish_dir }}
-          clean: true
-          clean-exclude: _preview/*  # keep existing previews from other PRs
-          target-folder: ${{ inputs.destination_dir }}
-          CNAME: ${{ inputs.cname }} # how can we set this for the new action?


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
As discussed in #129, the new deployment action doesn't support a `CNAME` argument for deployment to custom domains. But we don't need this. It's a one-time step to put a `CNAME` file at the root of the `gh-pages` branch, and we are only using this for two repositories (Foundations and Cookbook Gallery).

This PR removes the `cname` input option for the `deploy-book.yaml` workflow.

We'll need to tweak the workflow code that calls this from the Foundations and Cookbook Gallery repos.