### PR TITLE
Importlib metadata needs to be pinned

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -28,33 +28,6 @@ on:
         required: false
         default: '_build/html'
         type: string
-  workflow_dispatch:
-    inputs:
-      artifact_name:
-        description: 'Name of the artifact (zipped book) created by previous build step'
-        required: false
-        default: book-zip
-        type: string
-      destination_dir:
-        description: 'Path to publish to on GitHub Pages, relative to site root. We use this to deploy previews in a subdirectory.'
-        required: false
-        default: ''
-        type: string
-      is_preview:
-        description: 'Are we deploying a preview?'
-        required: false
-        default: 'false'
-        type: string
-      cname:
-        description: 'Custom domain name'
-        required: false
-        default: 'None'  # This is just a flag for whether to ignore this input
-        type: string
-      publish_dir:
-        description: 'Publish dir for the action'
-        required: false
-        default: '_build/html'
-        type: string
       
 jobs:
   deploy:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -29,6 +29,32 @@ on:
         default: '_build/html'
         type: string
   workflow_dispatch:
+    inputs:
+      artifact_name:
+        description: 'Name of the artifact (zipped book) created by previous build step'
+        required: false
+        default: book-zip
+        type: string
+      destination_dir:
+        description: 'Path to publish to on GitHub Pages, relative to site root. We use this to deploy previews in a subdirectory.'
+        required: false
+        default: ''
+        type: string
+      is_preview:
+        description: 'Are we deploying a preview?'
+        required: false
+        default: 'false'
+        type: string
+      cname:
+        description: 'Custom domain name'
+        required: false
+        default: 'None'  # This is just a flag for whether to ignore this input
+        type: string
+      publish_dir:
+        description: 'Publish dir for the action'
+        required: false
+        default: '_build/html'
+        type: string
       
 jobs:
   deploy:

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -49,7 +49,7 @@ jobs:
           miniforge-version: latest
 
       - name: Install Jupyterbook
-        run: conda install -c conda-forge jupyter-book
+        run: conda install -c conda-forge jupyter-book importlib-metadata=8.6.1
 
       - name: Check for config file
         id: check_config


### PR DESCRIPTION
Cookbook builds and link checks are failing with `ImportError: cannot import name 'EntryPoint' from 'importlib_metadata' (unknown location)` and all I've found is the building book uses importlib-metadata v8.6.1 and the failing on uses v8.7.0.

I updated the environment file of my notebook (making the build pass in https://github.com/ProjectPythia/pythia-cookoff-2025/pull/7) but link-checker still uses 8.7.0 unless we pin it here.
