### PR TITLE
Add MyST compatibility

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -83,10 +83,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      # `BASE_URL` determines the website is served from, including CSS & JS assets
-      # You may need to change this to `BASE_URL: ''`
-      BASE_URL: /${{ github.event.repository.name }}
     defaults:
       run:
         shell: bash -l {0}
@@ -267,6 +263,7 @@ jobs:
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
         env:
+          BASE_URL: /${{ github.repository }}
           ARM_USERNAME: ${{ secrets.ARM_USERNAME }}
           ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
           AQS_USERNAME: ${{ secrets.AQS_USERNAME }}

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -80,12 +80,17 @@ on:
         description: 'NASA Earthdata API Password'
         required: false
 
+env:
+  # `BASE_URL` determines the website is served from, including CSS & JS assets
+  # You may need to change this to `BASE_URL: ''`
+  BASE_URL: /${{ github.event.repository.name }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
     steps:
       - name: Checkout the code from the repo
         if: inputs.build_from_code_artifact == 'false'
@@ -108,10 +113,11 @@ jobs:
         run: |
           unzip pr_code.zip
           rm -f pr_code.zip   
-
-      # - name: Fetch Repo Name
-      #   id: repo-name
-      #   run: echo "value=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_OUTPUT  # just the repo name, not owner
+    
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
 
       - name: Get GitHub environment variables
         id: get-env
@@ -151,12 +157,17 @@ jobs:
           echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
           echo ${{ steps.env_change.outputs.any_changed }}
 
-      - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+      # - name: Setup Miniforge
+      #   uses: conda-incubator/setup-miniconda@v3
+      #   with:
+      #     miniforge-version: latest
+      #     python-version: "3.10"  # binderbot is failing with python 3.11
+      #     activate-environment: ${{ inputs.environment_name }}
+      
+      - name: Setup environment with micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          miniforge-version: latest
-          python-version: "3.10"  # binderbot is failing with python 3.11
-          activate-environment: ${{ inputs.environment_name }}
+          environment-file: ${{ inputs.environment_file }}
 
       - name: Set cache date
         if: inputs.use_cached_environment == 'true'
@@ -182,15 +193,15 @@ jobs:
           pip install git+https://github.com/pangeo-gallery/binderbot.git
           conda list
 
-      - name: Update execution environment
-        if: |
-          (inputs.use_cached_environment != 'true'
-          || steps.cache.outputs.cache-hit != 'true'
-          || steps.env_change.outputs.any_changed == 'true')
-          && steps.parse_config.outputs.execute_notebooks != 'binder'
-        run: |
-          conda env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-          conda list
+      # - name: Update execution environment
+      #   if: |
+      #     (inputs.use_cached_environment != 'true'
+      #     || steps.cache.outputs.cache-hit != 'true'
+      #     || steps.env_change.outputs.any_changed == 'true')
+      #     && steps.parse_config.outputs.execute_notebooks != 'binder'
+      #   run: |
+      #     conda env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
+      #     conda list
 
       - name: Get paths to notebook files
         if: |
@@ -255,11 +266,6 @@ jobs:
           with open('${{ inputs.path_to_notebooks }}/_config.yml', 'w') as f:
             yaml.dump(data, f)
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
         env:
@@ -275,17 +281,22 @@ jobs:
           cd ${{ inputs.path_to_notebooks }}
           ${{ inputs.build_command }}
 
-      - name: Zip the book
-        run: |
-          set -x
-          set -e
-          if [ -f book.zip ]; then
-              rm -rf book.zip
-          fi
-          zip -r book.zip ${{ inputs.path_to_notebooks }}/ ${{ inputs.output_path }}
+      # - name: Zip the book
+      #   run: |
+      #     set -x
+      #     set -e
+      #     if [ -f book.zip ]; then
+      #         rm -rf book.zip
+      #     fi
+      #     zip -r book.zip ${{ inputs.path_to_notebooks }}/ ${{ inputs.output_path }}
 
-      - name: Upload zipped book artifact
-        uses: actions/upload-artifact@v4
+      # - name: Upload zipped book artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ inputs.artifact_name }}
+      #     path: ./book.zip
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: ${{ inputs.artifact_name }}
-          path: ./book.zip
+          path: './_build/html'

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -83,8 +83,7 @@ on:
 env:
   # `BASE_URL` determines the website is served from, including CSS & JS assets
   # You may need to change this to `BASE_URL: ''`
-  # BASE_URL: /${{ github.event.repository.name }}
-  BASE_URL: '/cookbook-template'
+  BASE_URL: /${{ github.event.repository.name }}
 
 jobs:
   build:

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -18,11 +18,6 @@ on:
         required: false
         default: '.'
         type: string
-      # use_cached_environment:
-      #   description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
-      #   required: false
-      #   default: 'true'
-      #   type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
       artifact_name:
         description: 'The name to assign to the built book artifact.'
         required: false

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -83,6 +83,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # `BASE_URL` determines the website is served from, including CSS & JS assets
+      # You may need to change this to `BASE_URL: ''`
+      BASE_URL: /${{ github.event.repository.name }}
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -282,20 +282,20 @@ jobs:
           cd ${{ inputs.path_to_notebooks }}
           ${{ inputs.build_command }}
 
-      # - name: Zip the book
-      #   run: |
-      #     set -x
-      #     set -e
-      #     if [ -f book.zip ]; then
-      #         rm -rf book.zip
-      #     fi
-      #     zip -r book.zip ${{ inputs.path_to_notebooks }}/ ${{ inputs.output_path }}
+      - name: Zip the book
+        run: |
+          set -x
+          set -e
+          if [ -f book.zip ]; then
+              rm -rf book.zip
+          fi
+          zip -r book.zip ${{ inputs.path_to_notebooks }}/ ${{ inputs.output_path }}
 
-      # - name: Upload zipped book artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ inputs.artifact_name }}
-      #     path: ./book.zip
+      - name: Upload zipped book artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ./book.zip
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -255,6 +255,11 @@ jobs:
           with open('${{ inputs.path_to_notebooks }}/_config.yml', 'w') as f:
             yaml.dump(data, f)
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
         env:

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -80,10 +80,10 @@ on:
         description: 'NASA Earthdata API Password'
         required: false
 
-# env:
-#   # `BASE_URL` determines the website is served from, including CSS & JS assets
-#   # You may need to change this to `BASE_URL: ''`
-#   BASE_URL: /${{ github.event.repository.name }}
+env:
+  # `BASE_URL` determines the website is served from, including CSS & JS assets
+  # You may need to change this to `BASE_URL: ''`
+  BASE_URL: /${{ github.event.repository.name }}
 
 jobs:
   build:
@@ -123,39 +123,39 @@ jobs:
         id: get-env
         uses: FranzDiebold/github-env-vars-action@v2
       
-      - name: Check for config file
-        id: check_config
-        uses: andstor/file-existence-action@v3
-        with:
-          files: "${{ inputs.path_to_notebooks }}/_config.yml"
+      # - name: Check for config file
+      #   id: check_config
+      #   uses: andstor/file-existence-action@v3
+      #   with:
+      #     files: "${{ inputs.path_to_notebooks }}/_config.yml"
       
-      - name: Parse config file
-        id: parse_config
-        if: steps.check_config.outputs.files_exists == 'true'
-        uses: CumulusDS/get-yaml-paths-action@v1.0.2
-        with:
-          file: ${{ inputs.path_to_notebooks }}/_config.yml
-          execute_notebooks: execute.execute_notebooks
-          binderhub_url: sphinx.config.html_theme_options.launch_buttons.binderhub_url
-          timeout: execute.timeout
+      # - name: Parse config file
+      #   id: parse_config
+      #   if: steps.check_config.outputs.files_exists == 'true'
+      #   uses: CumulusDS/get-yaml-paths-action@v1.0.2
+      #   with:
+      #     file: ${{ inputs.path_to_notebooks }}/_config.yml
+      #     execute_notebooks: execute.execute_notebooks
+      #     binderhub_url: sphinx.config.html_theme_options.launch_buttons.binderhub_url
+      #     timeout: execute.timeout
 
-      - name: Echo values from config file
-        if: steps.check_config.outputs.files_exists == 'true'
-        run: |
-          echo ${{ steps.parse_config.outputs.execute_notebooks }}
-          echo ${{ steps.parse_config.outputs.binderhub_url }}
-          echo ${{ steps.parse_config.outputs.timeout }}
+      # - name: Echo values from config file
+      #   if: steps.check_config.outputs.files_exists == 'true'
+      #   run: |
+      #     echo ${{ steps.parse_config.outputs.execute_notebooks }}
+      #     echo ${{ steps.parse_config.outputs.binderhub_url }}
+      #     echo ${{ steps.parse_config.outputs.timeout }}
 
-      - name: Test for environment change
-        id: env_change
-        uses: tj-actions/changed-files@v46
-        with:
-          files: ${{ inputs.environment_file }}
+      # - name: Test for environment change
+      #   id: env_change
+      #   uses: tj-actions/changed-files@v46
+      #   with:
+      #     files: ${{ inputs.environment_file }}
 
-      - name: Echo environment change test result
-        run: |
-          echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
-          echo ${{ steps.env_change.outputs.any_changed }}
+      # - name: Echo environment change test result
+      #   run: |
+      #     echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
+      #     echo ${{ steps.env_change.outputs.any_changed }}
 
       # - name: Setup Miniforge
       #   uses: conda-incubator/setup-miniconda@v3
@@ -169,29 +169,29 @@ jobs:
         with:
           environment-file: ${{ inputs.environment_file }}
 
-      - name: Set cache date
-        if: inputs.use_cached_environment == 'true'
-        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+      # - name: Set cache date
+      #   if: inputs.use_cached_environment == 'true'
+      #   run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4
-        if: inputs.use_cached_environment == 'true'
-        with:
-          path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
-          # This should create a key that looks like 'linux-64-conda-environment.yml-[HASH]-_config.yml-[HASH]-DATE'
-          # Logic inspired by https://dev.to/epassaro/caching-anaconda-environments-on-github-actions-2d08
-          key: ${{ format('linux-64-conda-{0}-{1}-{2}-{3}-{4}', inputs.environment_file, hashFiles(format('{0}', inputs.environment_file)), '_config.yml', hashFiles(format('{0}', '_config.yml')), env.DATE )}}
-        id: cache
+      # - uses: actions/cache@v4
+      #   if: inputs.use_cached_environment == 'true'
+      #   with:
+      #     path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
+      #     # This should create a key that looks like 'linux-64-conda-environment.yml-[HASH]-_config.yml-[HASH]-DATE'
+      #     # Logic inspired by https://dev.to/epassaro/caching-anaconda-environments-on-github-actions-2d08
+      #     key: ${{ format('linux-64-conda-{0}-{1}-{2}-{3}-{4}', inputs.environment_file, hashFiles(format('{0}', inputs.environment_file)), '_config.yml', hashFiles(format('{0}', '_config.yml')), env.DATE )}}
+      #   id: cache
       
-      - name: Create book build environment
-        if: |
-          (inputs.use_cached_environment != 'true'
-          || steps.cache.outputs.cache-hit != 'true')
-          && steps.parse_config.outputs.execute_notebooks == 'binder'
-        run: |
-          conda install -c conda-forge jupyter-book pip
-          conda install sphinx-pythia-theme
-          pip install git+https://github.com/pangeo-gallery/binderbot.git
-          conda list
+      # - name: Create book build environment
+      #   if: |
+      #     (inputs.use_cached_environment != 'true'
+      #     || steps.cache.outputs.cache-hit != 'true')
+      #     && steps.parse_config.outputs.execute_notebooks == 'binder'
+      #   run: |
+      #     conda install -c conda-forge jupyter-book pip
+      #     conda install sphinx-pythia-theme
+      #     pip install git+https://github.com/pangeo-gallery/binderbot.git
+      #     conda list
 
       # - name: Update execution environment
       #   if: |

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -296,8 +296,3 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ./book.zip
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './_build/html'

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -123,39 +123,39 @@ jobs:
         id: get-env
         uses: FranzDiebold/github-env-vars-action@v2
       
-      # - name: Check for config file
-      #   id: check_config
-      #   uses: andstor/file-existence-action@v3
-      #   with:
-      #     files: "${{ inputs.path_to_notebooks }}/_config.yml"
+      - name: Check for config file
+        id: check_config
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "${{ inputs.path_to_notebooks }}/_config.yml"
       
-      # - name: Parse config file
-      #   id: parse_config
-      #   if: steps.check_config.outputs.files_exists == 'true'
-      #   uses: CumulusDS/get-yaml-paths-action@v1.0.2
-      #   with:
-      #     file: ${{ inputs.path_to_notebooks }}/_config.yml
-      #     execute_notebooks: execute.execute_notebooks
-      #     binderhub_url: sphinx.config.html_theme_options.launch_buttons.binderhub_url
-      #     timeout: execute.timeout
+      - name: Parse config file
+        id: parse_config
+        if: steps.check_config.outputs.files_exists == 'true'
+        uses: CumulusDS/get-yaml-paths-action@v1.0.2
+        with:
+          file: ${{ inputs.path_to_notebooks }}/_config.yml
+          execute_notebooks: execute.execute_notebooks
+          binderhub_url: sphinx.config.html_theme_options.launch_buttons.binderhub_url
+          timeout: execute.timeout
 
-      # - name: Echo values from config file
-      #   if: steps.check_config.outputs.files_exists == 'true'
-      #   run: |
-      #     echo ${{ steps.parse_config.outputs.execute_notebooks }}
-      #     echo ${{ steps.parse_config.outputs.binderhub_url }}
-      #     echo ${{ steps.parse_config.outputs.timeout }}
+      - name: Echo values from config file
+        if: steps.check_config.outputs.files_exists == 'true'
+        run: |
+          echo ${{ steps.parse_config.outputs.execute_notebooks }}
+          echo ${{ steps.parse_config.outputs.binderhub_url }}
+          echo ${{ steps.parse_config.outputs.timeout }}
 
-      # - name: Test for environment change
-      #   id: env_change
-      #   uses: tj-actions/changed-files@v46
-      #   with:
-      #     files: ${{ inputs.environment_file }}
+      - name: Test for environment change
+        id: env_change
+        uses: tj-actions/changed-files@v46
+        with:
+          files: ${{ inputs.environment_file }}
 
-      # - name: Echo environment change test result
-      #   run: |
-      #     echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
-      #     echo ${{ steps.env_change.outputs.any_changed }}
+      - name: Echo environment change test result
+        run: |
+          echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
+          echo ${{ steps.env_change.outputs.any_changed }}
 
       # - name: Setup Miniforge
       #   uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -16,7 +16,7 @@ on:
       path_to_notebooks:
         description: 'Location of the JupyterBook source relative to repo root'
         required: false
-        default: './'
+        default: '.'
         type: string
       use_cached_environment:
         description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
@@ -80,10 +80,10 @@ on:
         description: 'NASA Earthdata API Password'
         required: false
 
-env:
-  # `BASE_URL` determines the website is served from, including CSS & JS assets
-  # You may need to change this to `BASE_URL: ''`
-  BASE_URL: /${{ github.event.repository.name }}
+# env:
+#   # `BASE_URL` determines the website is served from, including CSS & JS assets
+#   # You may need to change this to `BASE_URL: ''`
+#   BASE_URL: /${{ github.event.repository.name }}
 
 jobs:
   build:
@@ -288,7 +288,7 @@ jobs:
           if [ -f book.zip ]; then
               rm -rf book.zip
           fi
-          zip -r book.zip ${{ inputs.path_to_notebooks }}/ ${{ inputs.output_path }}
+          zip -r book.zip ${{ inputs.path_to_notebooks }}/${{ inputs.output_path }}
 
       - name: Upload zipped book artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment_name:
-        description: 'Name of conda environment to activate'
+        description: 'Name of conda environment to activate (NO LONGER USED)'
         required: false
         default: 'cookbook-dev'
         type: string
@@ -18,11 +18,11 @@ on:
         required: false
         default: '.'
         type: string
-      use_cached_environment:
-        description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
-        required: false
-        default: 'true'
-        type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
+      # use_cached_environment:
+      #   description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
+      #   required: false
+      #   default: 'true'
+      #   type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
       artifact_name:
         description: 'The name to assign to the built book artifact.'
         required: false
@@ -85,8 +85,7 @@ on:
         required: false
 
 env:
-  # `BASE_URL` determines the website is served from, including CSS & JS assets
-  # You may need to change this to `BASE_URL: ''`
+  # the BASE_URL environment variable needs to be set if building with myst
   BASE_URL: ${{ inputs.base_url }}
 
 jobs:
@@ -160,52 +159,22 @@ jobs:
         run: |
           echo '(DEBUG) The value of steps.env_change.outputs.any_changed is:'
           echo ${{ steps.env_change.outputs.any_changed }}
-
-      # - name: Setup Miniforge
-      #   uses: conda-incubator/setup-miniconda@v3
-      #   with:
-      #     miniforge-version: latest
-      #     python-version: "3.10"  # binderbot is failing with python 3.11
-      #     activate-environment: ${{ inputs.environment_name }}
       
       - name: Setup environment with micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: ${{ inputs.environment_file }}
-
-      # - name: Set cache date
-      #   if: inputs.use_cached_environment == 'true'
-      #   run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-
-      # - uses: actions/cache@v4
-      #   if: inputs.use_cached_environment == 'true'
-      #   with:
-      #     path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
-      #     # This should create a key that looks like 'linux-64-conda-environment.yml-[HASH]-_config.yml-[HASH]-DATE'
-      #     # Logic inspired by https://dev.to/epassaro/caching-anaconda-environments-on-github-actions-2d08
-      #     key: ${{ format('linux-64-conda-{0}-{1}-{2}-{3}-{4}', inputs.environment_file, hashFiles(format('{0}', inputs.environment_file)), '_config.yml', hashFiles(format('{0}', '_config.yml')), env.DATE )}}
-      #   id: cache
       
-      # - name: Create book build environment
-      #   if: |
-      #     (inputs.use_cached_environment != 'true'
-      #     || steps.cache.outputs.cache-hit != 'true')
-      #     && steps.parse_config.outputs.execute_notebooks == 'binder'
-      #   run: |
-      #     conda install -c conda-forge jupyter-book pip
-      #     conda install sphinx-pythia-theme
-      #     pip install git+https://github.com/pangeo-gallery/binderbot.git
-      #     conda list
-
-      # - name: Update execution environment
-      #   if: |
-      #     (inputs.use_cached_environment != 'true'
-      #     || steps.cache.outputs.cache-hit != 'true'
-      #     || steps.env_change.outputs.any_changed == 'true')
-      #     && steps.parse_config.outputs.execute_notebooks != 'binder'
-      #   run: |
-      #     conda env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
-      #     conda list
+      - name: Create book build environment
+        if: |
+          (inputs.use_cached_environment != 'true'
+          || steps.cache.outputs.cache-hit != 'true')
+          && steps.parse_config.outputs.execute_notebooks == 'binder'
+        run: |
+          conda install -c conda-forge jupyter-book pip
+          conda install sphinx-pythia-theme
+          pip install git+https://github.com/pangeo-gallery/binderbot.git
+          conda list
 
       - name: Get paths to notebook files
         if: |

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -269,7 +269,7 @@ jobs:
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
         env:
-          BASE_URL: /${{ github.repository }}
+          # BASE_URL: /${{ github.repository }}
           ARM_USERNAME: ${{ secrets.ARM_USERNAME }}
           ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
           AQS_USERNAME: ${{ secrets.AQS_USERNAME }}

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -83,7 +83,8 @@ on:
 env:
   # `BASE_URL` determines the website is served from, including CSS & JS assets
   # You may need to change this to `BASE_URL: ''`
-  BASE_URL: /${{ github.event.repository.name }}
+  # BASE_URL: /${{ github.event.repository.name }}
+  BASE_URL: '/cookbook-template'
 
 jobs:
   build:

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -22,7 +22,7 @@ on:
         description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
         required: false
         default: 'true'
-        type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483${{ github.repository }}
+        type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
       artifact_name:
         description: 'The name to assign to the built book artifact.'
         required: false
@@ -58,7 +58,11 @@ on:
         required: false
         default: success
         type: string
-
+      base_url:
+        description: 'Determines where the website is served from, including CSS & JS assets (needed for MyST)'
+        required: false
+        default: '/${{ github.event.repository.name }}'
+        type: string
 
     secrets:
       ARM_USERNAME:
@@ -83,7 +87,7 @@ on:
 env:
   # `BASE_URL` determines the website is served from, including CSS & JS assets
   # You may need to change this to `BASE_URL: ''`
-  BASE_URL: /${{ github.event.repository.name }}
+  BASE_URL: ${{ inputs.base_url }}
 
 jobs:
   build:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -68,5 +68,5 @@ jobs:
           branch: gh-pages
           folder: ${{ inputs.publish_dir }}
           clean: true
-          # clean-exclude: _preview/*  # keep existing previews from other PRs
+          clean-exclude: _preview/*  # keep existing previews from other PRs
           # target-folder: ${{ inputs.destination_dir }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -59,26 +59,26 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: ${{ inputs.artifact_name }}
 
-      # - name: Unzip the book
-      #   run: |
-      #     rm -rf _build/html
-      #     unzip book.zip
-      #     rm -f book.zip
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: ${{ inputs.artifact_name }}
+      - name: Unzip the book
+        run: |
+          rm -rf _build/html
+          unzip book.zip
+          rm -f book.zip
 
       # - name: Deploy to GitHub Pages
-      #   uses: JamesIves/github-pages-deploy-action@v4
-      #   if: |
-      #     (github.ref == 'refs/heads/main')
+      #   id: deployment
+      #   uses: actions/deploy-pages@v4
       #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch: gh-pages
-      #     folder: ${{ inputs.publish_dir }}
-      #     clean: true
-      #     clean-exclude: _preview/*  # keep existing previews from other PRs
-      #     target-folder: ${{ inputs.destination_dir }}
+      #     artifact_name: ${{ inputs.artifact_name }}
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: |
+          (github.ref == 'refs/heads/main')
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: ${{ inputs.publish_dir }}
+          clean: true
+          clean-exclude: _preview/*  # keep existing previews from other PRs
+          target-folder: ${{ inputs.destination_dir }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -65,12 +65,6 @@ jobs:
           unzip book.zip
           rm -f book.zip
 
-      # - name: Deploy to GitHub Pages
-      #   id: deployment
-      #   uses: actions/deploy-pages@v4
-      #   with:
-      #     artifact_name: ${{ inputs.artifact_name }}
-
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         if: |
@@ -80,5 +74,5 @@ jobs:
           branch: gh-pages
           folder: ${{ inputs.publish_dir }}
           clean: true
-          clean-exclude: _preview/*  # keep existing previews from other PRs
-          target-folder: ${{ inputs.destination_dir }}
+          # clean-exclude: _preview/*  # keep existing previews from other PRs
+          # target-folder: ${{ inputs.destination_dir }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -26,9 +26,9 @@ on:
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -69,4 +69,4 @@ jobs:
           folder: ${{ inputs.publish_dir }}
           clean: true
           clean-exclude: _preview/*  # keep existing previews from other PRs
-          # target-folder: ${{ inputs.destination_dir }}
+          target-folder: ${{ inputs.destination_dir }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -23,13 +23,22 @@ on:
         required: false
         default: '_build/html'
         type: string
-      
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
     steps: 
       - uses: actions/checkout@v4
       
@@ -50,20 +59,26 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           name: ${{ inputs.artifact_name }}
 
-      - name: Unzip the book
-        run: |
-          rm -rf _build/html
-          unzip book.zip
-          rm -f book.zip
+      # - name: Unzip the book
+      #   run: |
+      #     rm -rf _build/html
+      #     unzip book.zip
+      #     rm -f book.zip
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        if: |
-          (github.ref == 'refs/heads/main')
+        id: deployment
+        uses: actions/deploy-pages@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: ${{ inputs.publish_dir }}
-          clean: true
-          clean-exclude: _preview/*  # keep existing previews from other PRs
-          target-folder: ${{ inputs.destination_dir }}
+          artifact_name: ${{ inputs.artifact_name }}
+
+      # - name: Deploy to GitHub Pages
+      #   uses: JamesIves/github-pages-deploy-action@v4
+      #   if: |
+      #     (github.ref == 'refs/heads/main')
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     branch: gh-pages
+      #     folder: ${{ inputs.publish_dir }}
+      #     clean: true
+      #     clean-exclude: _preview/*  # keep existing previews from other PRs
+      #     target-folder: ${{ inputs.destination_dir }}

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -24,12 +24,6 @@ on:
         default: '_build/html'
         type: string
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   deploy:
     environment:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -23,16 +23,13 @@ on:
         required: false
         default: '_build/html'
         type: string
-
+      
 jobs:
   deploy:
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -leo pipefail {0}
+        shell: bash -l {0}
     steps: 
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR updates the `build-book.yaml` workflow in two important ways:
- uses micromamba to set up the execution environment (much faster) and gets rid of the environment caching (no longer needed with micromamba performance)
- Add a new input argument `base_url` which is necessary for building with MyST

The calling workflow needs to specify `build_command: 'myst build --execute --html'` (and include mystmd in its environment file) for this to work with MyST.

Everything here *should* be backwards compatible but we will have to do some manual checking that existing non-MyST builds still work (#6 still unresolved).