### PR TITLE
Change default build commands to myst

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -26,7 +26,7 @@ on:
       build_command:
         description: 'The linux command to build the book or site.'
         required: false
-        default: 'jupyter-book build .'
+        default: 'myst build --execute --html'
         type: string
       output_path:
         description: 'Path to the built html content relative to `path_to_notebooks`'

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -111,11 +111,6 @@ jobs:
         run: |
           unzip pr_code.zip
           rm -f pr_code.zip   
-    
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
 
       - name: Get GitHub environment variables
         id: get-env

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -26,7 +26,7 @@ on:
       build_command:
         description: 'The linux command to run the link checker for the book or site'
         required: false
-        default: 'jupyter-book build --builder linkcheck .'
+        default: 'myst build --check-links'
         type: string
 
 


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR changes the default `build_command` input argument for both the `build_book.yaml` and `link_checker.yaml` to versions of `myst build` instead of `jupyter-book build`.

This will be a **breaking change** for non-mystified cookbook repos.