### PR TITLE
Add google analytics secrets

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -60,6 +60,12 @@ on:
         type: string
 
     secrets:
+      PRIVATE_KEY:
+        description: 'Google analytics key needed for metrics page on portal site'
+        required: false
+      PRIVATE_KEY_ID:
+        description: 'Google analytics key id needed for metrics page on portal site'
+        required: false
       ARM_USERNAME:
         description: 'Username for the ARM Data Discovery portal (https://adc.arm.gov/armlive/)'
         required: false
@@ -232,7 +238,8 @@ jobs:
       - name: Build the book
         # Assumption is that if execute_notebooks != 'binder' then the _config.yml file must be set to execute notebooks during build
         env:
-          # BASE_URL: /${{ github.repository }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_ID: ${{ secrets.PRIVATE_KEY_ID }}
           ARM_USERNAME: ${{ secrets.ARM_USERNAME }}
           ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
           AQS_USERNAME: ${{ secrets.AQS_USERNAME }}


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Adds support for passing the Google Analytics secrets needed to build the metrics page on the portal.

Should be fully backwards compatible but I'll check.